### PR TITLE
Enable automatic admin server startup

### DIFF
--- a/MMM-AI-Config.js
+++ b/MMM-AI-Config.js
@@ -1,7 +1,8 @@
 Module.register("MMM-AI-Config", {
   defaults: {
     openAiApiKey: "",
-    showDot: true
+    showDot: true,
+    adminPort: 5006
   },
 
   start: function() {
@@ -9,6 +10,10 @@ Module.register("MMM-AI-Config", {
     if (this.config.openAiApiKey) {
       this.sendSocketNotification("CHECK_KEY", this.config.openAiApiKey);
     }
+    this.sendSocketNotification("INIT_SERVER", {
+      port: this.config.adminPort,
+      openAiApiKey: this.config.openAiApiKey
+    });
   },
 
   socketNotificationReceived: function(notification, payload) {

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ This module provides a small web interface that leverages OpenAI to update your 
 
 ## Usage
 
-1. Set the environment variable `OPENAI_API_KEY` with your API key.
-2. Run `node server.js` inside this folder.
-3. Open `http://localhost:5006` in a browser and chat your configuration requests using the admin page served from the `public` directory (`admin.html`).
+1. Set the environment variable `OPENAI_API_KEY` with your API key (or provide it via the module configuration).
+2. Add the module to your `config.js` and start MagicMirror. The configuration interface will automatically launch.
+3. Open `http://<magicmirror-ip>:5006` (or your configured port) in a browser and chat your configuration requests using the admin page served from the `public` directory (`admin.html`).
+
+The port can be changed with the `adminPort` configuration option.
 
 Every change will back up the existing `config.js` file by appending the current timestamp to the file name before writing the new content returned by OpenAI.
 
@@ -22,7 +24,8 @@ Add the module to your `config.js`:
   position: "top_left",
   config: {
     openAiApiKey: "YOUR_OPENAI_API_KEY",
-    showDot: true
+    showDot: true,
+    adminPort: 5006
   }
 }
 ```

--- a/node_helper.js
+++ b/node_helper.js
@@ -1,14 +1,21 @@
 const NodeHelper = require("node_helper");
 const https = require("https");
+const http = require("http");
+const fs = require("fs");
+const path = require("path");
 
 module.exports = NodeHelper.create({
   start: function() {
     this.status = false;
+    this.server = null;
+    this.openAiKey = "";
   },
 
   socketNotificationReceived: function(notification, payload) {
     if (notification === "CHECK_KEY") {
       this.checkKey(payload);
+    } else if (notification === "INIT_SERVER") {
+      this.initServer(payload);
     }
   },
 
@@ -38,5 +45,123 @@ module.exports = NodeHelper.create({
     });
 
     req.end();
+  },
+
+  initServer: function(config) {
+    if (this.server) return;
+
+    const PORT = (config && config.port) || process.env.PORT || 5006;
+    this.openAiKey = (config && config.openAiApiKey) || process.env.OPENAI_API_KEY || "";
+
+    const MAGICMIRROR_ROOT = path.join(__dirname, "..", "..");
+    const CONFIG_FILE = path.join(MAGICMIRROR_ROOT, "config", "config.js");
+    const MODULES_DIR = path.join(MAGICMIRROR_ROOT, "modules");
+    const PUBLIC_DIR = path.join(__dirname, "public");
+
+    const readBody = (req, cb) => {
+      let data = "";
+      req.on("data", chunk => (data += chunk));
+      req.on("end", () => cb(data));
+    };
+
+    const sendOpenAIRequest = (prompt, cb) => {
+      const body = JSON.stringify({
+        model: "gpt-3.5-turbo",
+        messages: [{ role: "user", content: prompt }]
+      });
+
+      const options = {
+        hostname: "api.openai.com",
+        path: "/v1/chat/completions",
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(body),
+          Authorization: `Bearer ${this.openAiKey}`
+        }
+      };
+
+      const req = https.request(options, res => {
+        let data = "";
+        res.on("data", chunk => (data += chunk));
+        res.on("end", () => {
+          try {
+            const json = JSON.parse(data);
+            const reply = json.choices[0].message.content;
+            cb(null, reply);
+          } catch (err) {
+            cb(err);
+          }
+        });
+      });
+
+      req.on("error", err => cb(err));
+      req.write(body);
+      req.end();
+    };
+
+    const handleChat = (req, res) => {
+      readBody(req, data => {
+        let msg;
+        try {
+          msg = JSON.parse(data).message;
+        } catch (e) {}
+        if (!msg) {
+          res.writeHead(400);
+          return res.end("Invalid request");
+        }
+
+        let configText = "";
+        try {
+          configText = fs.readFileSync(CONFIG_FILE, "utf8");
+        } catch (e) {}
+        let modules = [];
+        try {
+          modules = fs.readdirSync(MODULES_DIR);
+        } catch (e) {}
+        const prompt = `Config:\n${configText}\nModules:${modules.join(", ")}\nUser request:${msg}\nReturn updated config.js file only.`;
+
+        sendOpenAIRequest(prompt, (err, answer) => {
+          if (err) {
+            res.writeHead(500);
+            return res.end(JSON.stringify({ error: "OpenAI error" }));
+          }
+          try {
+            const ts = new Date().toISOString().replace(/[:.]/g, "-");
+            fs.copyFileSync(CONFIG_FILE, `${CONFIG_FILE}.${ts}`);
+            fs.writeFileSync(CONFIG_FILE, answer);
+          } catch (e) {}
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ reply: answer }));
+        });
+      });
+    };
+
+    this.server = http.createServer((req, res) => {
+      if (req.method === "POST" && req.url === "/chat") {
+        return handleChat(req, res);
+      }
+      let filePath = path.join(PUBLIC_DIR, req.url === "/" ? "/admin.html" : req.url);
+      fs.readFile(filePath, (err, content) => {
+        if (err) {
+          res.writeHead(404);
+          res.end("Not found");
+        } else {
+          res.writeHead(200);
+          res.end(content);
+        }
+      });
+    });
+
+    this.server.listen(PORT, "0.0.0.0", () => {
+      console.log(`MMM-AI-Config admin interface running at http://0.0.0.0:${PORT}`);
+    });
+
+    // also check key on startup to update dot
+    if (this.openAiKey) {
+      this.checkKey(this.openAiKey);
+    } else {
+      this.sendSocketNotification("DOT_STATUS", false);
+    }
   }
 });


### PR DESCRIPTION
## Summary
- start config server through node_helper on MagicMirror startup
- send `INIT_SERVER` from module front-end
- document new `adminPort` option and automatic startup

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68539eb5fc748324bdf7562aa24bbb6a