### PR TITLE
Improve safe config handling

### DIFF
--- a/server.js
+++ b/server.js
@@ -10,6 +10,36 @@ const MODULES_DIR = path.join(MAGICMIRROR_ROOT, 'modules');
 const PUBLIC_DIR = path.join(__dirname, 'public');
 const OPENAI_KEY = process.env.OPENAI_API_KEY || '';
 
+function loadConfig() {
+  try {
+    delete require.cache[require.resolve(CONFIG_FILE)];
+    return require(CONFIG_FILE);
+  } catch (e) {
+    return null;
+  }
+}
+
+function saveConfig(configObj) {
+  try {
+    const ts = new Date().toISOString().replace(/[:.]/g, '-');
+    fs.copyFileSync(CONFIG_FILE, `${CONFIG_FILE}.${ts}`);
+    const output =
+      'var config = ' + JSON.stringify(configObj, null, 2) +
+      ';\nif (typeof module !== "undefined") { module.exports = config; }\n';
+    fs.writeFileSync(CONFIG_FILE, output);
+  } catch (e) {}
+}
+
+function applyChanges(configObj, changes) {
+  if (!changes || !Array.isArray(changes.modules)) return;
+  changes.modules.forEach(change => {
+    const target = configObj.modules.find(m => m.module === change.module);
+    if (target && change.config && typeof change.config === 'object') {
+      Object.assign(target, change.config);
+    }
+  });
+}
+
 function readBody(req, cb) {
   let data = '';
   req.on('data', chunk => data += chunk);
@@ -61,24 +91,29 @@ function handleChat(req, res) {
       return res.end('Invalid request');
     }
 
-    let config = '';
-    try { config = fs.readFileSync(CONFIG_FILE, 'utf8'); } catch (e) {}
+    const configObj = loadConfig() || { modules: [] };
     let modules = [];
     try { modules = fs.readdirSync(MODULES_DIR); } catch (e) {}
-    const prompt = `Config:\n${config}\nModules:${modules.join(', ')}\nUser request:${msg}\nReturn updated config.js file only.`;
+    const prompt =
+      `Current config: ${JSON.stringify(configObj)}\nModules: ${modules.join(', ')}\n` +
+      `User request: ${msg}\n` +
+      `Return ONLY JSON in the format {"modules":[{"module":"name","config":{"key":"value"}}]}`;
 
     sendOpenAIRequest(prompt, (err, answer) => {
       if (err) {
         res.writeHead(500);
-        return res.end(JSON.stringify({error:'OpenAI error'}));
+        return res.end(JSON.stringify({ error: 'OpenAI error' }));
       }
       try {
-        const ts = new Date().toISOString().replace(/[:.]/g, '-');
-        fs.copyFileSync(CONFIG_FILE, `${CONFIG_FILE}.${ts}`);
-        fs.writeFileSync(CONFIG_FILE, answer);
-      } catch (e) {}
-      res.writeHead(200, {'Content-Type':'application/json'});
-      res.end(JSON.stringify({reply: answer}));
+        const changes = JSON.parse(answer);
+        applyChanges(configObj, changes);
+        saveConfig(configObj);
+      } catch (e) {
+        res.writeHead(500);
+        return res.end(JSON.stringify({ error: 'Invalid AI response' }));
+      }
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ reply: answer }));
     });
   });
 }


### PR DESCRIPTION
## Summary
- add helpers to load, update, and save config safely
- request JSON changes from OpenAI instead of a full config.js file
- patch node helper and standalone server to apply AI changes to the current config

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6853b372c1b883249d760ac73acb9f96