### PR TITLE
Improve error messages in admin chat

### DIFF
--- a/public/admin.js
+++ b/public/admin.js
@@ -10,6 +10,8 @@ document.getElementById('form').addEventListener('submit', async function(e){
   let data = await res.json();
   if(data.reply){
     chat.innerHTML += `<div class="ai">${data.reply}</div>`;
+  }else if(data.error){
+    chat.innerHTML += `<div class="ai">Error: ${data.error}</div>`;
   }else{
     chat.innerHTML += `<div class="ai">Error</div>`;
   }


### PR DESCRIPTION
## Summary
- show the server-provided error message in admin chat so users can troubleshoot issues

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6853e9cff8bc832481c26382e52b1622