### PR TITLE
Improve logging and parsing for AI responses

### DIFF
--- a/server.js
+++ b/server.js
@@ -10,6 +10,18 @@ const MODULES_DIR = path.join(MAGICMIRROR_ROOT, 'modules');
 const PUBLIC_DIR = path.join(__dirname, 'public');
 const OPENAI_KEY = process.env.OPENAI_API_KEY || '';
 
+function parseJsonFromText(text) {
+  try {
+    return JSON.parse(text);
+  } catch (err) {
+    const match = text.match(/{[\s\S]*}/);
+    if (match) {
+      return JSON.parse(match[0]);
+    }
+    throw err;
+  }
+}
+
 function loadConfig() {
   try {
     delete require.cache[require.resolve(CONFIG_FILE)];
@@ -47,6 +59,7 @@ function readBody(req, cb) {
 }
 
 function sendOpenAIRequest(prompt, cb) {
+  console.log('Sending prompt to OpenAI:', prompt);
   const body = JSON.stringify({
     model: 'gpt-3.5-turbo',
     messages: [{role: 'user', content: prompt}]
@@ -67,6 +80,7 @@ function sendOpenAIRequest(prompt, cb) {
     let data = '';
     res.on('data', chunk => data += chunk);
     res.on('end', () => {
+      console.log('OpenAI raw response:', data);
       try {
         const json = JSON.parse(data);
         const reply = json.choices[0].message.content;
@@ -90,6 +104,7 @@ function handleChat(req, res) {
       res.writeHead(400);
       return res.end('Invalid request');
     }
+    console.log('User message:', msg);
 
     const configObj = loadConfig() || { modules: [] };
     let modules = [];
@@ -104,11 +119,13 @@ function handleChat(req, res) {
         res.writeHead(500);
         return res.end(JSON.stringify({ error: 'OpenAI error' }));
       }
+      console.log('AI answer:', answer);
       try {
-        const changes = JSON.parse(answer);
+        const changes = parseJsonFromText(answer);
         applyChanges(configObj, changes);
         saveConfig(configObj);
       } catch (e) {
+        console.error('Failed to parse AI response', answer, e);
         res.writeHead(500);
         return res.end(JSON.stringify({ error: 'Invalid AI response' }));
       }


### PR DESCRIPTION
## Summary
- add `parseJsonFromText` helper to node_helper.js
- log prompts, answers and parse errors in both server and helper

## Testing
- `npm test` *(fails: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_6853eac00bb88324a0dacfb568118317