### PR TITLE
Enhance AI prompt with module docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ This module provides a small web interface that leverages OpenAI to update your 
 
 The port can be changed with the `adminPort` configuration option.
 
+For better results, MMM-AI-Config reads the `README.md` file from every module
+in your MagicMirror `modules` directory. These READMEs should describe the
+configuration options available for each module so the AI can suggest accurate
+changes.
+
 After sending a request, the server returns the JSON changes proposed by OpenAI. The admin page will show these changes and let you approve or reject them. Only approved changes are written to `config.js`. When a change is applied, the previous file is backed up by appending the current timestamp to its name.
 
 ## MagicMirror Module

--- a/node_helper.js
+++ b/node_helper.js
@@ -184,8 +184,19 @@ module.exports = NodeHelper.create({
         try {
           modules = fs.readdirSync(MODULES_DIR);
         } catch (e) {}
+
+        const readmes = {};
+        modules.forEach(m => {
+          const p = path.join(MODULES_DIR, m, 'README.md');
+          try {
+            readmes[m] = fs.readFileSync(p, 'utf8').replace(/\r?\n/g, ' ').slice(0, 500);
+          } catch (e) {}
+        });
+
         const prompt =
-          `Current config: ${JSON.stringify(configObj)}\nModules: ${modules.join(", ")}\n` +
+          `Current config: ${JSON.stringify(configObj)}\n` +
+          `Modules: ${modules.join(', ')}\n` +
+          `Module docs: ${JSON.stringify(readmes)}\n` +
           `User request: ${msg}\n` +
           `Return ONLY JSON in the format {"modules":[{"module":"name","config":{"key":"value"}}]}`;
 

--- a/server.js
+++ b/server.js
@@ -126,9 +126,22 @@ function handleChat(req, res) {
 
     const configObj = loadConfig() || { modules: [] };
     let modules = [];
-    try { modules = fs.readdirSync(MODULES_DIR); } catch (e) {}
+    try {
+      modules = fs.readdirSync(MODULES_DIR);
+    } catch (e) {}
+
+    const readmes = {};
+    modules.forEach(m => {
+      const p = path.join(MODULES_DIR, m, 'README.md');
+      try {
+        readmes[m] = fs.readFileSync(p, 'utf8').replace(/\r?\n/g, ' ').slice(0, 500);
+      } catch (e) {}
+    });
+
     const prompt =
-      `Current config: ${JSON.stringify(configObj)}\nModules: ${modules.join(', ')}\n` +
+      `Current config: ${JSON.stringify(configObj)}\n` +
+      `Modules: ${modules.join(', ')}\n` +
+      `Module docs: ${JSON.stringify(readmes)}\n` +
       `User request: ${msg}\n` +
       `Return ONLY JSON in the format {"modules":[{"module":"name","config":{"key":"value"}}]}`;
 


### PR DESCRIPTION
## Summary
- include README details from each installed module when crafting the OpenAI prompt
- document README parsing behavior in usage section

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68584369d5148324b86baa26e6d135ac